### PR TITLE
Reset user state on /start command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -164,6 +164,9 @@ def start(update: Update, context: CallbackContext):
     chat_id = update.effective_chat.id
 
     completed_users.discard(chat_id)  # сбрасываем прогресс для этого пользователя
+    attempts.pop(chat_id, None)       # сбрасываем счетчик попыток
+    context.user_data.clear()
+    context.chat_data.clear()
 
     greeting = generate_greeting()
     context.bot.send_message(chat_id=chat_id, text=greeting)


### PR DESCRIPTION
## Summary
- Clear previous user progress and attempt counters when handling `/start`
- Reset per-user chat and user data to remove old dialogues

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_689c5f2157b08331a3d1cd14f55cf030