### PR TITLE
Send hint video after correct answer

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,8 +1,9 @@
 import logging
 import time
 import random
+from pathlib import Path
 import openai
-from telegram import Update
+from telegram import Update, InputFile
 from telegram.ext import Updater, CommandHandler, MessageHandler, Filters, CallbackContext
 from config import BOT_TOKEN, OPENAI_API_KEY
 from config import VALID_ANSWER_RAW_LIST
@@ -193,8 +194,16 @@ def check_number(update: Update, context: CallbackContext):
         completed_users.add(chat_id)
         context.bot.send_message(
             chat_id=chat_id,
-            text="✅ Вірно! А ось і твоя наступна підказка:\n\n📍 Зазирни туди, де ми вперше сказали 'я тебе кохаю' ❤️"
+            text="Вірно! А наступне відео підкаже тобі де шукати далі ;-)"
         )
+        time.sleep(5)
+        video_path = Path(__file__).resolve().parent.parent / "output.avi"
+        with open(video_path, "rb") as video:
+            context.bot.send_video(
+                chat_id=chat_id,
+                video=InputFile(video, filename="output.avi"),
+                supports_streaming=True,
+            )
         return
 
     attempts[chat_id] = attempts.get(chat_id, 0) + 1


### PR DESCRIPTION
## Summary
- Send confirmation text when answer is correct
- After 5s delay, load prepared `output.avi` from parent directory and send as video hint
- Ensure hint video is treated as streamable media by Telegram

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac362ca154833181c36ece593a464c